### PR TITLE
fix: Software installation failed using the installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ ecm_setup_version(${PROJECT_VERSION} VARIABLE_PREFIX QAPT
                   SOVERSION ${PROJECT_SOVERSION})
 
 set(QAPT_WORKER_VERSION ${PROJECT_SOVERSION})
-set(QAPT_WORKER_RDN org.kubuntu.qaptworker)
+set(QAPT_WORKER_RDN org.kubuntu.qapt6worker)
 set(QAPT_WORKER_RDN_VERSIONED ${QAPT_WORKER_RDN}${QAPT_WORKER_VERSION})
 
 # For forwarding into C++ convert them into properly excaped strings.

--- a/debian/libqapt3-qt6-runtime.install
+++ b/debian/libqapt3-qt6-runtime.install
@@ -1,4 +1,4 @@
-etc/dbus-1/system.d/org.kubuntu.qaptworker3-qt6.conf
-usr/bin/qaptworker3-qt6
-usr/share/dbus-1/system-services/org.kubuntu.qaptworker3-qt6.service
-usr/share/polkit-1/actions/org.kubuntu.qaptworker3-qt6.policy
+etc/dbus-1/system.d/org.kubuntu.qapt6worker3.conf
+usr/bin/qapt6worker3
+usr/share/dbus-1/system-services/org.kubuntu.qapt6worker3.service
+usr/share/polkit-1/actions/org.kubuntu.qapt6worker3.policy

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -78,7 +78,6 @@ bool Cache::open()
 pkgDepCache *Cache::depCache() const
 {
     Q_D(const Cache);
-    qDebug() << "Accessing dependency cache";
     return *d->cache;
 }
 

--- a/src/dbusinterfaces_p.h.cmake
+++ b/src/dbusinterfaces_p.h.cmake
@@ -13,7 +13,7 @@ static const char s_workerReverseDomainName[] = @QAPT_WORKER_RDN_VERSIONED_STRIN
 
 // This will fail regardless of whether the var is present or not as this is
 // hard typed anyway.
-typedef OrgKubuntuQaptworker@QAPT_WORKER_VERSION@Interface WorkerInterface;
-typedef OrgKubuntuQaptworker@QAPT_WORKER_VERSION@TransactionInterface TransactionInterface;
+typedef OrgKubuntuQapt6worker@QAPT_WORKER_VERSION@Interface WorkerInterface;
+typedef OrgKubuntuQapt6worker@QAPT_WORKER_VERSION@TransactionInterface TransactionInterface;
 
 #endif // QAPT_DBUSINTERFACES_P_H

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -193,7 +193,6 @@ bool PackagePrivate::setInUpdatePhase(bool inUpdatePhase)
 Package::Package(QApt::Backend* backend, pkgCache::PkgIterator &packageIter)
         : d(new PackagePrivate(packageIter, backend))
 {
-    qDebug() << "Created package object for:" << QLatin1String(packageIter.Name());
 }
 
 Package::~Package()
@@ -208,7 +207,6 @@ const pkgCache::PkgIterator &Package::packageIterator() const
 
 QLatin1String Package::name() const
 {
-    qDebug() << "Accessed package name:" << QLatin1String(d->packageIter.Name());
     return QLatin1String(d->packageIter.Name());
 }
 

--- a/src/worker/CMakeLists.txt
+++ b/src/worker/CMakeLists.txt
@@ -1,18 +1,17 @@
-set(WORKER_NAME qaptworker${QAPT_WORKER_VERSION}-qt6)
-set(WORKER_RDN_VERSIONED ${QAPT_WORKER_RDN_VERSIONED}-qt6)
+set(WORKER_NAME qapt6worker${QAPT_WORKER_VERSION})
 
 configure_file(org.kubuntu.qaptworker.transaction.xml.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/${QAPT_WORKER_RDN_VERSIONED}.transaction.xml)
 configure_file(org.kubuntu.qaptworker.xml.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/${QAPT_WORKER_RDN_VERSIONED}.xml)
 configure_file(org.kubuntu.qaptworker.service.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/${WORKER_RDN_VERSIONED}.service)
+    ${CMAKE_CURRENT_BINARY_DIR}/${QAPT_WORKER_RDN_VERSIONED}.service)
 configure_file(qaptworker.actions.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/${WORKER_RDN_VERSIONED}.actions)
+    ${CMAKE_CURRENT_BINARY_DIR}/${QAPT_WORKER_RDN_VERSIONED}.actions)
 configure_file(org.kubuntu.qaptworker.policy.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/${WORKER_RDN_VERSIONED}.policy)
+    ${CMAKE_CURRENT_BINARY_DIR}/${QAPT_WORKER_RDN_VERSIONED}.policy)
 configure_file(org.kubuntu.qaptworker.conf.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/${WORKER_RDN_VERSIONED}.conf)
+    ${CMAKE_CURRENT_BINARY_DIR}/${QAPT_WORKER_RDN_VERSIONED}.conf)
 configure_file(urihelper.h.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/urihelper.h)
 
@@ -83,15 +82,15 @@ if (NOT DEFINED SYSCONF_INSTALL_DIR)
     set(SYSCONF_INSTALL_DIR "/etc")
 endif()
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${WORKER_RDN_VERSIONED}.service
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${QAPT_WORKER_RDN_VERSIONED}.service
         DESTINATION ${DBUS_SYSTEM_SERVICES_INSTALL_DIR})
 
 if(KF5Auth_FOUND)
-    kauth_install_actions(${QAPT_WORKER_RDN_VERSIONED} ${CMAKE_CURRENT_BINARY_DIR}/${WORKER_RDN_VERSIONED}.actions)
+    kauth_install_actions(${QAPT_WORKER_RDN_VERSIONED} ${CMAKE_CURRENT_BINARY_DIR}/${QAPT_WORKER_RDN_VERSIONED}.actions)
 else()
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${WORKER_RDN_VERSIONED}.policy
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${QAPT_WORKER_RDN_VERSIONED}.policy
         DESTINATION ${CMAKE_INSTALL_PREFIX}/share/polkit-1/actions)
 endif()
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${WORKER_RDN_VERSIONED}.conf
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${QAPT_WORKER_RDN_VERSIONED}.conf
     DESTINATION ${SYSCONF_INSTALL_DIR}/dbus-1/system.d/)

--- a/src/worker/org.kubuntu.qaptworker.service.cmake
+++ b/src/worker/org.kubuntu.qaptworker.service.cmake
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=@QAPT_WORKER_RDN_VERSIONED@
-Exec=/usr/bin/qaptworker@QAPT_WORKER_VERSION@-qt6
+Exec=/usr/bin/qapt6worker@QAPT_WORKER_VERSION@
 User=root
 


### PR DESCRIPTION
The DBus service name does not match the configuration file name, causing the service to fail to start properly.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-320589.html
