### PR TITLE
feat: add reverse provides lookup methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ build/
 .vscode/
 
 # cmake generated files
+.claude
+AGENTS.md
+.trellis

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -1053,6 +1053,32 @@ QMap<QString, QString> Package::providesListEnhance() const
    return provides;
 }
 
+QStringList Package::reverseProvidesList() const
+{
+    QStringList reverseProvidesList;
+
+    // Iterate over all packages that provide this package
+    for (pkgCache::PrvIterator Prv = d->packageIter.ProvidesList(); !Prv.end(); ++Prv) {
+        reverseProvidesList << QLatin1String(Prv.OwnerPkg().Name());
+    }
+
+    return reverseProvidesList;
+}
+
+QMap<QString, QString> Package::reverseProvidesListEnhance() const
+{
+    QMap<QString, QString> reverseProvides;
+
+    // Iterate over all packages that provide this package
+    for (pkgCache::PrvIterator Prv = d->packageIter.ProvidesList(); !Prv.end(); ++Prv) {
+        QString providerName = QLatin1String(Prv.OwnerPkg().Name());
+        QString provideVersion = QLatin1String(Prv.ProvideVersion());
+        reverseProvides.insert(providerName, provideVersion);
+    }
+
+    return reverseProvides;
+}
+
 QStringList Package::recommendsList() const
 {
     QStringList recommends;

--- a/src/package.h
+++ b/src/package.h
@@ -181,7 +181,7 @@ public:
     QString priority() const;
 
    /**
-    * Returns the files that this package has installed. 
+    * Returns the files that this package has installed.
     *
     * \return The file list of the package. If the package is not installed, it
     *         will return an empty list.
@@ -266,7 +266,7 @@ public:
     *
     * This function can be used to return data from custom control fields
     * which do not have an official function inside APT to retrieve them.
-    * 
+    *
     * For example, the supportedUntil() function uses this function to
     * retrieve the value of the "Supported" field, which is Ubuntu-specific
     * and does not have an APT function with which to obtain it.
@@ -502,6 +502,26 @@ public:
      * \return A \c QMap<QString, QString> of packages that this package provides and versions.
      */
     QMap<QString, QString> providesListEnhance() const;
+
+    /**
+     * Returns a list of the names of all the packages that provide this package.
+     * (Reverse provides)
+     *
+     * \return A \c QStringList of packages that provide this package
+     *
+     * @since 3.0.10
+     */
+    QStringList reverseProvidesList() const;
+
+    /**
+     * Returns a map of packages that provide this package with their versions.
+     * (Reverse provides with version info)
+     *
+     * \return A \c QMap<QString, QString> where keys are package names and values are the versions they provide
+     *
+     * @since 3.0.10
+     */
+    QMap<QString, QString> reverseProvidesListEnhance() const;
 
    /**
     * Returns a list of the names of all the packages that this package recommends.


### PR DESCRIPTION
Add reverse provides query functionality to Package class with two new
methods:

1. reverseProvidesList(): Returns QStringList of package names that
provide this virtual package by iterating over pkgCache::PrvIterator
2. reverseProvidesListEnhance(): Returns QMap<QString, QString> mapping
provider names to their provide versions using ProvideVersion()

These methods utilize the APT cache's ProvidesList via
d->packageIter.ProvidesList() to traverse all packages declaring they
provide this package, accessing OwnerPkg() for provider identification.
This enables applications to resolve which concrete packages satisfy
virtual package dependencies, completing the provides relationship API
alongside existing providesList() methods.

Also includes minor whitespace cleanup in header documentation and
updates .gitignore to exclude AI assistant configuration files (.claude,
AGENTS.md, .trellis).

Influence:
1. Test reverseProvidesList() with virtual packages having multiple
concrete providers
2. Test reverseProvidesListEnhance() returns correct provider-to-version
mappings
3. Verify empty list/map returned for packages with no providers
4. Test with complex virtual packages that have version-specific
provides
5. Verify iterator correctly handles all entries in ProvidesList without
missing providers
6. Test behavior with both installed and available (not installed)
packages

feat: 添加反向提供查询方法

向 Package 类添加反向提供查询功能，包含两个新方法：

1. reverseProvidesList()：通过遍历 pkgCache::PrvIterator 返回提供此虚拟
软件包的软件包名称列表
2. reverseProvidesListEnhance()：使用 ProvideVersion() 返回将提供者名称
映射到其提供版本的 QMap<QString, QString>

这些方法通过 d->packageIter.ProvidesList() 利用 APT 缓存的 ProvidesList
遍历所有声明提供此软件包的软件包，通过 OwnerPkg() 获取提供者标识。
这使应用程序能够解析哪些具体软件包满足虚拟软件包依赖关系，与现有的
providesList() 方法一起完善了提供关系 API。

同时包含对头文件文档的轻微空白清理，并更新 .gitignore 以排除 AI 助手配置
文件（.claude、AGENTS.md、.trellis）。

Influence:
1. 测试 reverseProvidesList() 在有多个具体提供者的虚拟软件包上的表现
2. 测试 reverseProvidesListEnhance() 返回正确的提供者到版本映射
3. 验证没有提供者的软件包返回空列表/映射
4. 测试具有版本特定提供的复杂虚拟软件包
5. 验证迭代器正确处理 ProvidesList 中的所有条目，不遗漏提供者
6. 测试对已安装和可用（未安装）软件包的行为表现

BUG: https://pms.uniontech.com/bug-view-358267.html
